### PR TITLE
Closes #2 - `q` - dividend yield - and `cp` - call/put flag - were not handled correctly.

### DIFF
--- a/calcbsimpvol/src/calcbsimpvol.py
+++ b/calcbsimpvol/src/calcbsimpvol.py
@@ -184,9 +184,9 @@ def calcbsimpvol(arg_dict):
     # supplied as a scalar value or previously modeled and supplied as an array / vector
     if size(r) == 1:
         r = r * ones((g, h))
-    if size(q):
+    if size(q) == 1:
         q = q * ones((g, h))
-    if size(cp):
+    if size(cp) == 1:
         cp = cp * ones((g, h))
 
     p = asarray([-0.969271876255, 0.097428338274, 1.750081126685])


### PR DESCRIPTION

the matlab reference `isscalar` was ported to `np.size() == 1`
but only used for `r` -the risk free rate.
It should have been used for `q` and `cp`, too.