### PR TITLE
Closes #1 - include upper constraint on scipy package version at `1.3.3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib
 numpy<=1.15
-scipy>=1.1.0
+scipy>=1.1.0, <1.3.3


### PR DESCRIPTION
packages above `1.3.3` broke the pypy3 CI pipeline.
So an upper constraint would assure that `calcbsimpvol` works on `CPython` and `PyPy`.

Another approach would be to split the `requirements.txt` to `requirements_pypy.txt` and `requirements_cpython.txt` but that would be really confusing.

Actually, this smells like an environment issue with the CI setup, but that will take more time to resolve compared to the issues blocked from being merged to master due to the failing CI.